### PR TITLE
Use dynamic settings instead of config resolver

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,8 @@ parameters:
 services:
     edgar_ez_cdn.cdn_listener:
         class: %edgar_ez_cdn.cdn_listener_class%
-        calls:
-            - [setContainer, [@service_container]]
         tags:
             - { name: kernel.event_subscriber }
+        calls:
+            - [setDomain, [$domain;edgar_ez_cdn$]]
+            - [setExtensions, [$extensions;edgar_ez_cdn$]]


### PR DESCRIPTION
This replaces `ContainerAware` + `ConfigResolver` with injection of dynamic settings from `services.yml`. We find it easier to maintain, maybe you'll think the same.

The settings are passed with setters and not the constructor so that the values can be updated on siteaccess change without resetting the service.
